### PR TITLE
use absolute path in "read more" link in site header

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -24,7 +24,7 @@
       <a href="https://foiathedead.org">
         <img id="logo" src="https://foiathedead.org/imgs/ftd-logo.png">
       </a>
-      <h1 id="headline">FOIA The Dead has released 3,601 pages of FBI records on 50 public figures. <a href="about" id="about-link">read more »</a></h1>
+      <h1 id="headline">FOIA The Dead has released 3,601 pages of FBI records on 50 public figures. <a href="/about" id="about-link">read more »</a></h1>
     </div>
     <div id="content">
       <ul id="results-list">


### PR DESCRIPTION
The "read more" link in the site header currently uses a relative path. Post-pagination, this breaks if you're on a page other than the first, e.g. on page 2 it links to https://foiathedead.org/2/about. This should fix that.